### PR TITLE
feat(vim): auto color switch for vim over `sshr`

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -186,9 +186,11 @@ let g:one_allow_italics = 1 " for vim-one
 let s:set_background_lock = 0
 function! SetBackground(...)
     let init = get(a:, 1, 0) " init only the argument is given
-    if has('mac') && !s:set_background_lock
+    if !s:set_background_lock &&
+        \   (has('mac') || (s:is_sshr() && $LC_OS =~ "Darwin"))
         let s:set_background_lock = 1
-        if system('defaults read -g AppleInterfaceStyle') =~ "Dark"
+        let cmd='defaults read -g AppleInterfaceStyle'
+        if system(cmd) =~ "Dark" || (s:is_sshr() && s:remote_system(cmd) =~ "Dark")
             " don't change background if already set or not init
             if &background != 'dark' || !init
                 doautocmd User BackGroundDark
@@ -198,6 +200,13 @@ function! SetBackground(...)
         endif
         let s:set_background_lock = 0
     endif
+endfunction
+" check if it's a SSH session
+function! s:is_sshr()
+    return !empty($SSHR_PORT)
+endfunction
+function! s:remote_system(cmd)
+    return system("ssh " . $LC_USER . "@localhost -o StrictHostKeyChecking=no -p " . $SSHR_PORT . " '" . a:cmd . "'")
 endfunction
 " if SIGWINCH is supported, trigger it when receive a SIGWINCH signal
 " otherwise, it's needed to call SetBackground manually

--- a/.zshrc
+++ b/.zshrc
@@ -146,7 +146,11 @@ if command -v nvim &> /dev/null; then
 fi
 alias yadm='yadm --yadm-repo $HOME/.git'
 sshr(){
-    sshr_port=$(((RANDOM % 10000) + 10000))
+    # ssh to host firstly to get an aviailable port
+    # this solution is from https://unix.stackexchange.com/a/164948
+    sshr_port=$(ssh -t -R 0:localhost:22 $1 -o RemoteCommand='exit' 2>&1 |
+        grep 'Allocated port' | awk '/port/ {print $3;}')
+    echo "Use port $sshr_port for remote forward to localhost:22"
     ssh -t -R ${sshr_port}:localhost:22 $1 -o RemoteCommand="
         export SHELL=/home/%r/.local/bin/zsh;
         export SSHR_PORT=$sshr_port;

--- a/.zshrc
+++ b/.zshrc
@@ -145,6 +145,14 @@ if command -v nvim &> /dev/null; then
     alias vimdiff='nvimdiff'
 fi
 alias yadm='yadm --yadm-repo $HOME/.git'
+sshr(){
+    sshr_port=$(((RANDOM % 10000) + 10000))
+    ssh -t -R ${sshr_port}:localhost:22 $1 -o RemoteCommand="
+        export SHELL=/home/%r/.local/bin/zsh;
+        export SSHR_PORT=$sshr_port;
+        export LC_USER=$USER LC_OS=$(uname -s) TERM_PROGRAM=$TERM_PROGRAM;
+        exec \$SHELL -l"
+}
 # }}}
 
 # environment variables {{{


### PR DESCRIPTION
Currently, auto color switch for vim only works on local, but not for remote vim, because remote server can't detect state of local machine. But remote forward of SSH make it possible.
Thus, connecting to server by `sshr`, and then `vim` can detect local machine color scheme.